### PR TITLE
Make README right-to-left

### DIFF
--- a/THOUSANDS-SEPARATOR/README.md
+++ b/THOUSANDS-SEPARATOR/README.md
@@ -1,17 +1,21 @@
-# تست‌های جدا کننده اعداد(هزارگان)
+<h1 dir="rtl">تست‌های جدا کننده اعداد(هزارگان)</h1>
+
+<p dir="rtl">
 در این تست بدنبال این بودم که بهترین و درست ترین جایگاه علامت جداکننده اعداد در کدام موقعیت خط نوشتاری هست. در بالا یا روی خط کرسی اصلی.
+</p>
+<p dir="rtl">
 و در چه حالت بالاترین خوانایی را دارد.
-
+</p>
+<p dir="rtl">
 در دمو‌های زیر میتوانید چندین فونت رو مورد تست و تجزیه و تحلیل  قرار بدید.
+</p>
 
-## demo
+<h2 dir="rtl">demo</h2>
 
-فونت نیکا : http://font-store.github.io/research/THOUSANDS-SEPARATOR/Nika/
-
-فونت پرستو  : http://font-store.github.io/research/THOUSANDS-SEPARATOR/Parasto/
-
-فونت پی فونت: http://font-store.github.io/research/THOUSANDS-SEPARATOR/PFont
-
-فونت صمیم: http://font-store.github.io/research/THOUSANDS-SEPARATOR/Samim
-
-فونت وزیر:http://font-store.github.io/research/THOUSANDS-SEPARATOR/Vazir/
+<ul dir="rtl">
+<li>فونت نیکا : http://font-store.github.io/research/THOUSANDS-SEPARATOR/Nika/</li>
+<li>فونت پرستو  : http://font-store.github.io/research/THOUSANDS-SEPARATOR/Parasto/</li>
+<li>فونت پی فونت: http://font-store.github.io/research/THOUSANDS-SEPARATOR/PFont</li>
+<li>فونت صمیم: http://font-store.github.io/research/THOUSANDS-SEPARATOR/Samim</li>
+<li>فونت وزیر:http://font-store.github.io/research/THOUSANDS-SEPARATOR/Vazir/</li>
+</div>


### PR DESCRIPTION
I didn't know GitHub Markdown can render right-to-left HTML as well. Unfortunantlely you can't wrap everything in a wrapper element with `dir="rtl"` and expect inner markdown inherit from it. I had to explicitly declare `dir` for each element. But it works!
